### PR TITLE
Fix gemspec encoding

### DIFF
--- a/aureus.gemspec
+++ b/aureus.gemspec
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 $:.push File.expand_path('../lib', __FILE__)
 require 'aureus/version'
 


### PR DESCRIPTION
Hi Joël,

Your name give some conflict if you don't set utf-8 encoding.

```
There was a SyntaxError while loading aureus.gemspec: 
syntax error, unexpected end-of-input, expecting keyword_end
  s.author = 'Joël Gähhwiler'
```
